### PR TITLE
Feature: exclude folders using wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Automatically creates a local backup of the vault.
 - Backup by calling archiver (7-Zip, WinRAR, Bandizip)
 - Retry after failures
 - Create specific file
+- Ignore folders and files using wildcards
 
 ## How to use
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ interface LocalBackupPluginSettings {
 	oneWayUnixSavePathValue: string;
 	oneWayLifecycleValue: string;
 	oneWayBackupsPerDayValue: string;
+	excludedDirectoriesValue: string;
 }
 
 const DEFAULT_SETTINGS: LocalBackupPluginSettings = {
@@ -62,6 +63,7 @@ const DEFAULT_SETTINGS: LocalBackupPluginSettings = {
 	oneWayUnixSavePathValue: "",
 	oneWayLifecycleValue: "3",
 	oneWayBackupsPerDayValue: "3",
+	excludedDirectoriesValue: "",
 };
 
 export default class LocalBackupPlugin extends Plugin {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -31,6 +31,7 @@ interface LocalBackupPluginSettings {
 	archiveFileTypeValue: string;
 	archiverWinPathValue: string;
 	archiverUnixPathValue: string;
+	excludedDirectoriesValue: string; // Added for excluded directories
 }
 
 export class LocalBackupSettingTab extends PluginSettingTab {
@@ -160,6 +161,21 @@ export class LocalBackupSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.fileNameFormatValue)
 					.onChange(async (value: string) => {
 						this.plugin.settings.fileNameFormatValue = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName("Excluded directories")
+			.setDesc(
+				"Specify directories to exclude from backup. Use comma-separated list with wildcards (e.g., .git, .trash, node_modules, *.mp4)"
+			)
+			.addText((text: TextComponent) =>
+				text
+					.setPlaceholder(".git, .trash, node_modules")
+					.setValue(this.plugin.settings.excludedDirectoriesValue)
+					.onChange(async (value: string) => {
+						this.plugin.settings.excludedDirectoriesValue = value;
 						await this.plugin.saveSettings();
 					})
 			);


### PR DESCRIPTION
# Feature: exclude folders using wildcards

This PR adds a new feature to "ignore or exclude folders and files using wildcards". This is in response to both #49 and #58 and my own workflow that involves locally baking up Obsidian vaults with `.git` folders.

## Summary of Changes

- `README.md`: Added feature to list of features.
- `src/main.ts`: Add new `excludedDirectoriesValue` variable.
- `src/settings.ts`: Add new setting `.setName("Excluded directories")` to store ignored folders.
- `src/utils.ts`: Adds new functionality using `const excludedPatterns = this.plugin.settings.excludedDirectoriesValue`.

## Testing

- The plugin was tested using two separate Obsidian vaults, cycling different ignore patterns like excluding `.git` and `.obsidian` and it worked without faults in Windows.
